### PR TITLE
Add clamping to X25519 keys

### DIFF
--- a/pkg/crypto/curve25519/curve25519.go
+++ b/pkg/crypto/curve25519/curve25519.go
@@ -128,6 +128,11 @@ func GenerateKeys(rand io.Reader) ([]byte, []byte, error) {
 		return nil, nil, err
 	}
 
+	// clamping, see https://cr.yp.to/ecdh.html
+	privateKey[0] &= 248
+	privateKey[31] &= 127
+	privateKey[31] |= 64
+
 	curve25519.ScalarBaseMult(publicKey, privateKey)
 	return publicKey[:], privateKey[:], nil
 }


### PR DESCRIPTION
X25519 keys are not exactly a random 256 bit string, there are a few
clamping operations that need to be done after to make a conformant key,
as documented in the specification.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>